### PR TITLE
working code - removing hardcoded root and setting node attribuets

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,8 @@ Attributes
 ----------
 The following attributes affect the behavior of the chef-client program when running as a service through one of the service recipes, or in cron with the cron recipe, or are used in the recipes for various settings that require flexibility.
 
-```will make pretty later - Suresh
-default['chef_client']['d_owner']='root'
-default['chef_client']['d_group']='root'
-```
-
+* `node['chef_client']['d_owner']` - Adding attribute for user who owns files created by cookbook (default if not specified: root)
+* `node['chef_client']['d_group']` -  Adding attribute for group who owns files created by cookbook (default if not specified: root) 
 * `node['chef_client']['interval']` - Sets `Chef::Config[:interval]`
   via command-line option for number of seconds between chef-client
   daemon runs. Default 1800.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ Attributes
 ----------
 The following attributes affect the behavior of the chef-client program when running as a service through one of the service recipes, or in cron with the cron recipe, or are used in the recipes for various settings that require flexibility.
 
+```will make pretty later - Suresh
+default['chef_client']['d_owner']='root'
+default['chef_client']['d_group']='root'
+```
+
 * `node['chef_client']['interval']` - Sets `Chef::Config[:interval]`
   via command-line option for number of seconds between chef-client
   daemon runs. Default 1800.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,8 @@
 #
 # Users can add other configuration options through attributes in
 # their favorite way (role, 'site' cookbooks, etc).
+default['chef_client']['d_owner']='root'
+default['chef_client']['d_group']='root'
 default['chef_client']['config'] = {
   'chef_server_url' => Chef::Config[:chef_server_url],
   'validation_client_name' => Chef::Config[:validation_client_name],

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,8 +23,6 @@
 #
 # Users can add other configuration options through attributes in
 # their favorite way (role, 'site' cookbooks, etc).
-default['chef_client']['d_owner']='root'
-default['chef_client']['d_group']='root'
 default['chef_client']['config'] = {
   'chef_server_url' => Chef::Config[:chef_server_url],
   'validation_client_name' => Chef::Config[:validation_client_name],

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -56,7 +56,7 @@ module Opscode
               recursive true
               mode 00755 if dir == 'log_dir'
               owner d_owner 
-              group = node['root_group'].nil? ? 'root' : node['chef_client']['d_group'] 
+              group = node['chef_client']['d_group'].nil? ? node['root_group'] : node['chef_client']['d_group'] 
             end
           end
         end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -38,13 +38,23 @@ module Opscode
         if ['windows'].include?(node['platform'])
           wmi_property_from_query(:name, "select * from Win32_UserAccount where sid like 'S-1-5-21-%-500' and LocalAccount=True")
         else
-          'root'
+          # require 'pry'; binding.pry 
+          "#{node['chef_client']['d_owner']}"
+        end
+      end
+      def root_group
+        if ['windows'].include?(node['platform'])
+          wmi_property_from_query(:name, "select * from Win32_UserAccount where sid like 'S-1-5-21-%-500' and LocalAccount=True")
+        else
+          # require 'pry'; binding.pry 
+          "#{node['chef_client']['d_group']}"
         end
       end
 
       def create_directories
         # root_owner is not in scope in the block below.
         d_owner = root_owner
+        d_group = root_group
         %w{run_path cache_path backup_path log_dir conf_dir}.each do |dir|
           # Do not redefine the resource if it exist
           begin
@@ -54,7 +64,7 @@ module Opscode
               recursive true
               mode 00755 if dir == 'log_dir'
               owner d_owner
-              group node['root_group']
+              group d_group
             end
           end
         end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -38,15 +38,18 @@ module Opscode
         if ['windows'].include?(node['platform'])
           wmi_property_from_query(:name, "select * from Win32_UserAccount where sid like 'S-1-5-21-%-500' and LocalAccount=True")
         else
-          # require 'pry'; binding.pry 
-          "#{node['chef_client']['d_owner']}"
+          defined?(node['chef_client']['d_owner']).nil? ? 'root' : node['chef_client']['d_owner']
         end
       end
 
-      
+      def root_group
+        defined?(node['chef_client']['d_group']).nil? ? node['root_group'] : node['chef_client']['d_group']
+      end
+
       def create_directories
         # root_owner is not in scope in the block below.
         d_owner = root_owner
+        d_group = root_group
         %w{run_path cache_path backup_path log_dir conf_dir}.each do |dir|
           # Do not redefine the resource if it exist
           begin
@@ -55,8 +58,8 @@ module Opscode
             directory node['chef_client'][dir] do
               recursive true
               mode 00755 if dir == 'log_dir'
-              owner d_owner 
-              group = node['chef_client']['d_group'].nil? ? node['root_group'] : node['chef_client']['d_group'] 
+              owner = d_owner
+              group = d_group
             end
           end
         end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -42,19 +42,11 @@ module Opscode
           "#{node['chef_client']['d_owner']}"
         end
       end
-      def root_group
-        if ['windows'].include?(node['platform'])
-          wmi_property_from_query(:name, "select * from Win32_UserAccount where sid like 'S-1-5-21-%-500' and LocalAccount=True")
-        else
-          # require 'pry'; binding.pry 
-          "#{node['chef_client']['d_group']}"
-        end
-      end
 
+      
       def create_directories
         # root_owner is not in scope in the block below.
         d_owner = root_owner
-        d_group = root_group
         %w{run_path cache_path backup_path log_dir conf_dir}.each do |dir|
           # Do not redefine the resource if it exist
           begin
@@ -63,8 +55,8 @@ module Opscode
             directory node['chef_client'][dir] do
               recursive true
               mode 00755 if dir == 'log_dir'
-              owner d_owner
-              group d_group
+              owner d_owner 
+              group = node['root_group'].nil? ? 'root' : node['chef_client']['d_group'] 
             end
           end
         end

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -69,9 +69,9 @@ end
 
 # We need to set these local variables because the methods aren't
 # available in the Chef::Resource scope
- 
 d_owner = root_owner
-d_group = root_owner
+d_group = root_group
+# d_group = node['root_group']
 
 
 template "#{node["chef_client"]["conf_dir"]}/client.rb" do

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -24,7 +24,7 @@
 class ::Chef::Recipe
   include ::Opscode::ChefClient::Helpers
 end
-
+ 
 # chef_node_name = Chef::Config[:node_name] == node['fqdn'] ? false : Chef::Config[:node_name]
 
 if node['chef_client']['log_file'].is_a? String and node['chef_client']['init_style'] != 'runit'
@@ -55,7 +55,6 @@ if log_path != 'STDOUT' #~FC023
     mode 00640
   end
 end
-
 chef_requires = []
 node['chef_client']['load_gems'].each do |gem_name, gem_info_hash|
   gem_info_hash ||= {}
@@ -70,8 +69,10 @@ end
 
 # We need to set these local variables because the methods aren't
 # available in the Chef::Resource scope
+ 
 d_owner = root_owner
-d_group = node['root_group']
+d_group = root_owner
+
 
 template "#{node["chef_client"]["conf_dir"]}/client.rb" do
   source 'client.rb.erb'


### PR DESCRIPTION
Currently cookbook does not support chef client running as a custom user.

Modify `root_group` helper to support two attributes which will will allow client.rb and logrotate to work in an enterprise environment where chef client is ran as a non-privileged user.

If attributes are not set helper will default to root/root

``` ruby
default['chef_client']['d_owner']='root'
default['chef_client']['d_group']='root'
```
